### PR TITLE
Removing stack.yaml and removing dev flag from stack-8.10.yaml

### DIFF
--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -1,8 +1,3 @@
 resolver: lts-18.23
 packages:
 - '.'
-extra-deps:
-flags:
-  hedis:
-    dev: true
-extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,0 @@
-stack-8.10.yaml


### PR DESCRIPTION
Relates to [commercialhaskell/stack#5004](https://redirect.github.com/commercialhaskell/stack/issues/5004).

Since we're not intending to update past GHC-8.10.7 I'm letting it fall back to a version-specific file.